### PR TITLE
add support to get Clusterversion and specify source image

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: kata-operator
 rules:
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
   - ""
   - machineconfiguration.openshift.io
   resources:  

--- a/pkg/apis/kataconfiguration/v1alpha1/kataconfig_types.go
+++ b/pkg/apis/kataconfiguration/v1alpha1/kataconfig_types.go
@@ -17,6 +17,8 @@ type KataConfigSpec struct {
 
 // KataInstallConfig is a placeholder struct
 type KataInstallConfig struct {
+	// SourceImage is the name of the kata-deploy image
+	SourceImage string `json:"sourceImage"`
 }
 
 // KataConfigStatus defines the observed state of KataConfig


### PR DESCRIPTION
We need support to specify the config.SourceImage field in the custom resource. This is added by the first patch.
The second patch lets the kata-operator service account GET the clusterversion object.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>