### PR TITLE
Check version

### DIFF
--- a/deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml
+++ b/deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml
@@ -2,6 +2,9 @@ apiVersion: kataconfiguration.openshift.io/v1alpha1
 kind: KataConfig
 metadata:
   name: example-kataconfig 
+spec:
+  config:
+     sourceImage: quay.io/isolatedcontainers/kata-operator-payload:4.5.4
 #spec:
 #  kataConfigPoolSelector:
 #    matchLabels:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -34,8 +34,7 @@ spec:
       containers:
         - name: kata-operator
           # Replace this with the built image name
-          #image: quay.io/isolatedcontainers/kata-operator:v1.0
-          image: quay.io/harpatil/kata-operator:v.0.1 
+          image: quay.io/isolatedcontainers/kata-operator:v2.0
           command:
           - kata-operator
           imagePullPolicy: Always

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: kata-operator
 rules:
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
   - ""
   - machineconfiguration.openshift.io
   resources:  

--- a/pkg/controller/kataconfig/kataconfig_controller.go
+++ b/pkg/controller/kataconfig/kataconfig_controller.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	nodeapi "k8s.io/api/node/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -144,20 +142,6 @@ func contains(list []string, s string) bool {
 		}
 	}
 	return false
-}
-
-func getClientSet() (*kubernetes.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", "")
-	if err != nil {
-		return nil, err
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset, nil
 }
 
 // IsOpenShift detects if we are running in OpenShift using the discovery client

--- a/pkg/controller/kataconfig/openshift_reconciler.go
+++ b/pkg/controller/kataconfig/openshift_reconciler.go
@@ -155,7 +155,7 @@ func (r *ReconcileKataConfigOpenShift) processDaemonsetForCR(operation DaemonOpe
 					Containers: []corev1.Container{
 						{
 							Name:            "kata-install-pod",
-							Image:           "quay.io/isolatedcontainers/kata-operator-daemon:v1.0",
+							Image:           "quay.io/isolatedcontainers/kata-operator-daemon:v2.0",
 							ImagePullPolicy: "Always",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &runPrivileged,


### PR DESCRIPTION
Make sure the kata-operator-payload image can be installed on the version of OCP in use.
This is done by comparing the clusterversion against the tag of the SourceImage field in the kataconfig custom resource. If they don't match the reconcile will fail with an error until the custom resource is changed. 

Signed-off-by: Jens Freimann <jfreiman@redhat.com>