### PR TITLE
rbac: allow operator to get clusterversion

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: kata-operator
 rules:
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
   - ""
   - machineconfiguration.openshift.io
   resources:  


### PR DESCRIPTION
This allows the operator/service account to fetch the configv1 clusterversion 

Signed-off-by: Jens Freimann <jfreimann@redhat.com>