### PR TITLE
daemonset: add preStop handler to clean up

### DIFF
--- a/pkg/controller/kataconfig/openshift_reconciler.go
+++ b/pkg/controller/kataconfig/openshift_reconciler.go
@@ -140,6 +140,13 @@ func (r *ReconcileKataConfigOpenShift) processDaemonsetForCR(operation DaemonOpe
 								Privileged: &runPrivileged,
 								RunAsUser:  &runAsUser,
 							},
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.Handler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"rm", "-rf", "/opt/kata-install", "/usr/local/kata/"},
+									},
+								},
+							},
 							Command: []string{"/bin/sh", "-c", fmt.Sprintf("/daemon --resource %s --operation %s", r.kataConfig.Name, operation)},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
Add a preStop handler to delete temporary directories the daemonset
creates during installation. This will help when the pods are deleted
during an ongoing installation.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>