### PR TITLE
use latest daemon image 

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -34,8 +34,7 @@ spec:
       containers:
         - name: kata-operator
           # Replace this with the built image name
-          #image: quay.io/isolatedcontainers/kata-operator:v1.0
-          image: quay.io/isolatedcontainers/kata-operator:v1.0
+          image: quay.io/isolatedcontainers/kata-operator:4.6
           command:
           - kata-operator
           imagePullPolicy: Always

--- a/pkg/controller/kataconfig/openshift_reconciler.go
+++ b/pkg/controller/kataconfig/openshift_reconciler.go
@@ -134,7 +134,7 @@ func (r *ReconcileKataConfigOpenShift) processDaemonsetForCR(operation DaemonOpe
 					Containers: []corev1.Container{
 						{
 							Name:            "kata-install-pod",
-							Image:           "quay.io/isolatedcontainers/kata-operator-daemon:v1.0",
+							Image:           "quay.io/isolatedcontainers/kata-operator-daemon:4.6",
 							ImagePullPolicy: "Always",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &runPrivileged,


### PR DESCRIPTION
Use latest daemon image which has support to check the OCP version and choose the correct payload image. 

Fixes #2