### PR TITLE
Prevent multiple KataConfig CRs

### DIFF
--- a/pkg/controller/kataconfig/openshift_reconciler_test.go
+++ b/pkg/controller/kataconfig/openshift_reconciler_test.go
@@ -3,6 +3,7 @@ package kataconfig
 import (
 	"context"
 	"testing"
+	"time"
 
 	kataconfigurationv1alpha1 "github.com/openshift/kata-operator/pkg/apis/kataconfiguration/v1alpha1"
 	"github.com/openshift/kata-operator/pkg/generated/clientset/versioned/scheme"
@@ -66,6 +67,182 @@ func TestKataConfigCreation(t *testing.T) {
 	}
 	if k.Name != kataconfig.Name {
 		t.Fatalf("Unexpected kataconfig found (%v)", kataconfig)
+	}
+}
+
+func TestMultipleKataConfigCreation(t *testing.T) {
+	// The oldest CR creation time set at 0001-01-01 00:00:00 +0000 UTC by default
+	kataconfig := &kataconfigurationv1alpha1.KataConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "kataconfiguration.openshift.io/v1alpha1",
+			Kind:       "KataConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "example-kataconfig",
+		},
+	}
+	kataconfig.Status.TotalNodesCount = 3
+
+	// This CR's creation time is set at yesterday
+	kataconfig2 := &kataconfigurationv1alpha1.KataConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "kataconfiguration.openshift.io/v1alpha1",
+			Kind:       "KataConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "example-kataconfig2",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-24 * time.Hour)),
+		},
+	}
+	kataconfig2.Status.TotalNodesCount = 3
+
+	// This CR's creation time set at rigt now today
+	kataconfig3 := &kataconfigurationv1alpha1.KataConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "kataconfiguration.openshift.io/v1alpha1",
+			Kind:       "KataConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "example-kataconfig3",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+		},
+	}
+	kataconfig3.Status.TotalNodesCount = 3
+
+	// Objects to track in the fake client.
+	objs := []runtime.Object{kataconfig, kataconfig2, kataconfig3}
+
+	s := scheme.Scheme
+
+	s.AddKnownTypes(kataconfigurationv1alpha1.SchemeGroupVersion, kataconfig)
+	s.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.DaemonSet{})
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.NodeList{})
+
+	if err := kataconfigurationv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add route scheme: (%v)", err)
+	}
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, objs...)
+
+	kataConfigList := &kataconfigurationv1alpha1.KataConfigList{}
+	listOpts := []client.ListOption{}
+	err := cl.List(context.TODO(), kataConfigList, listOpts...)
+
+	if len(kataConfigList.Items) != 3 {
+		t.Fatalf("Unable to find all kataconfig CRs")
+	}
+	if err != nil {
+		t.Fatalf("list kataconfig: (%v)", err)
+	}
+
+	k := &kataconfigurationv1alpha1.KataConfig{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "example-kataconfig"}, k)
+	if err != nil {
+		t.Fatalf("Error getting kataconfig: (%v)", err)
+	}
+	if k.Name != kataconfig.Name {
+		t.Fatalf("Unexpected kataconfig found (%v)", kataconfig)
+	}
+
+	k2 := &kataconfigurationv1alpha1.KataConfig{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "example-kataconfig2"}, k2)
+	if err != nil {
+		t.Fatalf("Error getting kataconfig: (%v)", err)
+	}
+
+	if k2.Name != kataconfig2.Name {
+		t.Fatalf("Unexpected kataconfig found (%v)", kataconfig2)
+	}
+
+	k3 := &kataconfigurationv1alpha1.KataConfig{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "example-kataconfig3"}, k3)
+	if err != nil {
+		t.Fatalf("Error getting kataconfig: (%v)", err)
+	}
+
+	if k3.Name != kataconfig3.Name {
+		t.Fatalf("Unexpected kataconfig found (%v)", kataconfig3)
+	}
+
+	k1t := k.GetCreationTimestamp()
+	k2t := k2.GetCreationTimestamp()
+	k3t := k3.GetCreationTimestamp()
+
+	if !k1t.Before(&k2t) {
+		t.Fatalf("Incorrect creation time stamps found %+v and %+v", k1t, k2t)
+	}
+
+	if !k2t.Before(&k3t) {
+		t.Fatalf("Incorrect creation time stamps found %+v and %+v", k2t, k3t)
+	}
+
+	r := &ReconcileKataConfigOpenShift{client: cl, scheme: s}
+
+	// Let's reconcile first CR
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: k.Name,
+		},
+	}
+
+	_, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "example-kataconfig"}, k)
+	if err != nil {
+		t.Fatalf("Error getting kataconfig: (%v)", err)
+	}
+
+	// This is the oldest CR, so this should be processed by the reconciliation loop
+	if k.Status.InstallationStatus.Failed.FailedNodesCount == -1 {
+		t.Fatal("Oldest KataConfig CR is marked duplicate")
+	}
+
+	// Let's reconcile the CR after the first one
+	req = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: k2.Name,
+		},
+	}
+
+	_, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "example-kataconfig2"}, k2)
+	if err != nil {
+		t.Fatalf("Error getting kataconfig2: (%v)", err)
+	}
+
+	// This CR should be marked duplicate before it's created after the first one
+	if k2.Status.InstallationStatus.Failed.FailedNodesCount != -1 {
+		t.Fatal("Newer KataConfig CR is not marked duplicate")
+	}
+
+	// Now let's reconcile the 3rd CR
+	req = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: k3.Name,
+		},
+	}
+
+	_, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: "example-kataconfig3"}, k3)
+	if err != nil {
+		t.Fatalf("Error getting kataconfig3: (%v)", err)
+	}
+
+	// Even this CR should be marked duplicate because it's created after the first one
+	if k3.Status.InstallationStatus.Failed.FailedNodesCount != -1 {
+		t.Fatal("Newer KataConfig CR is not marked duplicate")
 	}
 }
 


### PR DESCRIPTION
Do not allow controller to process multiple KataConfig CRs. 

Signed-off-by: Harshal Patil <harpatil@redhat.com>