### PR TITLE
add /host prefix to directories to be cleaned up

### DIFF
--- a/pkg/controller/kataconfig/openshift_reconciler.go
+++ b/pkg/controller/kataconfig/openshift_reconciler.go
@@ -210,7 +210,7 @@ func (r *ReconcileKataConfigOpenShift) processDaemonsetForCR(operation DaemonOpe
 							Lifecycle: &corev1.Lifecycle{
 								PreStop: &corev1.Handler{
 									Exec: &corev1.ExecAction{
-										Command: []string{"rm", "-rf", "/opt/kata-install", "/usr/local/kata/"},
+										Command: []string{"/bin/sh", "-c", "rm -rf /host/opt/kata-install /host/usr/local/kata/"},
 									},
 								},
 							},


### PR DESCRIPTION
The preStop hook command is not run in a chroot environment, so we
need to delete /host/<dir> instead of just /<dir>

Signed-off-by: Jens Freimann <jfreimann@redhat.com>