### PR TITLE
fix command run at preStop event

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -164,7 +164,7 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCR(operation DaemonOp
 							Lifecycle: &corev1.Lifecycle{
 								PreStop: &corev1.Handler{
 									Exec: &corev1.ExecAction{
-										Command: []string{"rm", "-rf", "/opt/kata-install", "/usr/local/kata/"},
+										Command: []string{"/bin/sh", "-c", "rm -rf /host/opt/kata-install /host/usr/local/kata/"},
 									},
 								},
 							},


### PR DESCRIPTION
Add /host to directories in rm command because it is not run in chroot
environment.

Fixes: #24 
Signed-off-by: Jens Freimann <jfreimann@redhat.com>