### PR TITLE
Fix example fedora yaml runtimeclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ oc describe kataconfig example-kataconfig
 and look at the field 'Completed nodes' in the status. If the value matches the number of worker nodes the installation is completed.
 
 #### Runtime Class
-Once the kata runtime binaries are successfully installed on the intended workers, Kata Operator will create a [runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/) `kata-oc`. This runtime class can be used to deploy the pods that will use the Kata Runtime.
+Once the kata runtime binaries are successfully installed on the intended workers, Kata Operator will create a [runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/) `kata`. This runtime class can be used to deploy the pods that will use the Kata Runtime.
 
 #### Run an Example Pod using the Kata Runtime
 ```

--- a/config/samples/example-fedora.yaml
+++ b/config/samples/example-fedora.yaml
@@ -13,4 +13,4 @@ spec:
         - containerPort: 8080
       command: ["python3"]
       args: [ "-m", "http.server", "8080"]
-  runtimeClassName: kata-oc
+  runtimeClassName: kata


### PR DESCRIPTION
We've switched to 'kata' as runtimeclass because it is what upstream 
kata-deploy uses as well and users got confused about the -oc.

The changes is already in the release-4.6 branch but on the master branch
we are still missing this change. 

Fix the example pod file accordingly.
