### PR TITLE
change kata-operator-daemon container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/jensfr/kata-operator:4.7.0
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -153,9 +153,8 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCR(operation DaemonOp
 					NodeSelector:       nodeSelector,
 					Containers: []corev1.Container{
 						{
-							Name: "kata-install-pod",
-							// Image:           "quay.io/isolatedcontainers/kata-operator-daemon:v1.0",
-							Image:           "docker.io/pharshal/kata-install-daemon:0.1.1",
+							Name:            "kata-install-pod",
+							Image:           "quay.io/isolatedcontainers/kata-operator-daemon:4.7",
 							ImagePullPolicy: "Always",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &runPrivileged,


### PR DESCRIPTION
When code for the new operator was merged first we missed that
there is still a private test container image referenced in the
code.

This patch fixes it and changes the container image to
quay.io/isolatedcontainers/kata-operator-daemon:4.7

Signed-off-by: Jens Freimann <jfreimann@redhat.com>