### PR TITLE
Fix description and URLs of containers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ oc delete kataconfig example-kataconfig
 ### Openshift
 The kata-operator uses three containers:
 
-Container image name | Description | Repository
+Container image name | Description | Container repository
 ---------------| ----------- | ----------
- _kata-operator_ |  It contains the controller part of the operator that watches and manages the kataconfig custom resource. It runs as a cluster scoped container. The operator itself is build with operator-sdk. | https://github.com/isolatedcontainers/kata-operator
- _kata-operator-daemon_ | The daemon part of the operator that runs on the nodes and performs the actual installation. It pulls down the container kata-operator-payload image. | https://github.com/isolatedcontainers/kata-operator-daemon
- _kata-operator-payload_ | The payload that is used by the daemon to install the kata binaries and dependencies (like e.g. QEMU). It's a container image with (currently) RPMs in it that will be installed on the chosen worker nodes by the daemon. | https://github.com/isolatedcontaineres/kata-operator-payload
+ _kata-operator_ |  It contains the controller part of the operator that watches and manages the kataconfig custom resource. It runs as a cluster scoped container. The operator itself is build with operator-sdk. | https://quay.io/isolatedcontainers/kata-operator
+ _kata-operator-daemon_ | The daemon part of the operator that runs on the nodes and performs the actual installation. It pulls down the container kata-operator-payload image. Dockerfile and other content can be found in images/daemon/ subdirectory of this github repository | https://quay.io/isolatedcontainers/kata-operator-daemon
+ _kata-operator-payload_ | The payload that is used by the daemon to install the kata binaries and dependencies (like e.g. QEMU). It's a container image with (currently) RPMs in it that will be installed on the chosen worker nodes by the daemon. Dockerfile and other content can be found in images/payload subdirectory of this github repository. | https://quay.io/isolatedcontaineres/kata-operator-payload
 
 ## Upgrading Kata
 


### PR DESCRIPTION
To make it more clear I change the column "Repository" to "Container repository" and also add a sentence in the description as to where the Dockerfile can be found. 
Also fix the URls from github.com to quay.io.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>