### PR TITLE
fix README, change release-4.7 to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An operator to perform lifecycle management (install/upgrade/uninstall) of [Kata
 
    ```
    git clone https://github.com/openshift/kata-operator 
-   git checkout -b release-4.7 --track origin/release-4.7
+   git checkout -b master --track origin/master
    ```
 3. Install the Kata Operator on the cluster,
 


### PR DESCRIPTION
There is no release-4.7 branch as of today. Change the README to mention master branch instead.