### PR TITLE
Custom payload images

### DIFF
--- a/config/samples/configmap_payload.yaml
+++ b/config/samples/configmap_payload.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  creationTimestamp: 2016-02-18T19:14:38Z
+  name: payload-config
+  namespace: kata-operator
+data:
+  # change to your custom payload repository:tag value
+  daemon.payload: quay.io/user/repository:test

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -114,8 +114,11 @@ func (r *KataConfigOpenShiftReconciler) Reconcile(req ctrl.Request) (ctrl.Result
 }
 
 func (r *KataConfigOpenShiftReconciler) processDaemonsetForCR(operation DaemonOperation) *appsv1.DaemonSet {
-	runPrivileged := true
-	var runAsUser int64 = 0
+	var (
+		runPrivileged           = true
+		configmapOptional       = true
+		runAsUser         int64 = 0
+	)
 
 	dsName := "kata-operator-daemon-" + string(operation)
 	labels := map[string]string{
@@ -172,6 +175,20 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCR(operation DaemonOp
 								{
 									Name:      "hostroot",
 									MountPath: "/host",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "KATA_PAYLOAD_IMAGE",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "payload-config",
+											},
+											Key:      "daemon.payload",
+											Optional: &configmapOptional,
+										},
+									},
 								},
 							},
 						},

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,39 @@
+# Hacking on the kata-operator
+
+## Using a custom kata-operator-payload image
+
+Sometimes we need to test new builds of RPMs, for example to
+verify a bug in QEMU, kata-runtime or other packages.
+
+The ConfigMap will be added to the Pod spec of the installer daemon pods as
+an environment variable. If the variable is set the daemon will use it. If not
+the default mechanism for choosing the payload image is used.
+
+The purpose of this feature is for development purposes only. When the
+ConfigMap is used the operator will print a warning that using self-built RPMs
+taints the kataconfig installation.
+
+To set a custom image create a configmap. Open the file deploy/configmap_payload.yaml and
+change
+
+    daemon.payload: quay.io/<username>/mykatapayload:mytag
+
+## How to create a custom payload container image
+
+Based on an existing and known to work set of RPMs it is possible to replace
+packages.
+
+Note: it is not possible to add additonal RPMs this way
+Note: the example below is using podman but docker could be used as well
+
+An example:
+
+1. skopeo copy docker://quay.io/jensfr/kata-operator-payload:4.7.0 oci:/tmp/kata-operator-payload:4.7.0
+2. oci-image-tool unpack --ref name=4.7.0  /tmp/kata-operator-payload kata-operator-payload-unpacked-4.7.0
+3. cp -r /tmp/kata-operator-payload-unpacked-4.7.0/packages $KATA_OPERATOR_REPO/images/payload
+4. cd $KATA_OPERATOR_REPO/images/payload
+5. replace RPMs in packages/ with custom RPMs
+6. podman build --no-cache -f Dockerfile.custom quay.io/<username>/mykatapayload:mytag
+7. podman push quay.io/<username>/mykatapayload:mytag
+
+To use the custom payload container image use the payload-config configmap as described above

--- a/images/daemon/pkg/daemon/kata_openshift.go
+++ b/images/daemon/pkg/daemon/kata_openshift.go
@@ -380,9 +380,18 @@ func installRPMs(k *KataOpenShift) error {
 		fmt.Println(err)
 	}
 
-	srcRef, err := alltransports.ParseImageName("docker://quay.io/isolatedcontainers/kata-operator-payload:" + k.PayloadTag)
+	payloadImage := os.Getenv("KATA_PAYLOAD_IMAGE")
+	if payloadImage == "" {
+		payloadImage = "docker://quay.io/isolatedcontainers/kata-operator-payload:" + k.PayloadTag
+	} else {
+		log.Println("WARNING: kataconfig installation is tainted")
+		log.Println("Using env variable KATA_PAYLOAD_IMAGE " + payloadImage)
+		payloadImage = "docker://" + payloadImage
+	}
+
+	srcRef, err := alltransports.ParseImageName(payloadImage)
 	if err != nil {
-		fmt.Println("Invalid source name")
+		fmt.Println("Invalid source name of payload container image: " + payloadImage)
 		return err
 	}
 	destRef, err := alltransports.ParseImageName("oci:/opt/kata-install/kata-image:latest")


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
    
    Sometimes we need to test new builds of RPMs, for example to
    verify a bug in QEMU, kata-runtime or other packages.
    
**- What I did**

    For this purpose the user can now add a configmap with a single data
    entry that specifies a URL to a container image, e.g.
    quay.io/someuser/repository:tag.
    
    The ConfigMap will be added to the Pod spec of the installer daemon pods as an
    environment variable. If the variable is set the daemon will use it. If
    not the default mechanism for choosing the payload image is used.
    
    The purpose of this feature is for development purposes only. When the
    ConfigMap is used the operator will print a warning that using
    self-built RPMs taints the kataconfig installation.
    
    Also add a description in docs/DEVELOPMENT.md on how to use the ConfigMap
    and how to build a custom payload image.

**- How to verify it**

    Create a configMap and apply it.  See docs/DEVELOPMENT.md. Then check the log of kata-operator-daemon to see if it is using the custom payload 
    image specified in the configMap.

**- Description for the changelog**
   The user can now add a configmap with a single data
    entry that specifies a URL to a container image