### PR TITLE
add example catalogsource

### DIFF
--- a/config/samples/catalogsource.yaml
+++ b/config/samples/catalogsource.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: kataconfig-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/isolatedcontainers/kata-operator-catalog:latest
+  displayName: Kata container Operators
+  publisher: Red Hat
+  updateStrategy:
+    registryPoll: 
+      interval: 30m


### PR DESCRIPTION
This example catalogsource can be applied to an OpenShift cluster to be
able to install the operator via the web console.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

**- Description of the problem which is fixed/What is the use case**

**- What I did**
This example catalogsource can be applied to an OpenShift cluster to be
able to install the operator via the web console.

**- How to verify it**

oc apply -f config/samples/catalogsource.yaml
Go to web console and try to install via Operatorhub

**- Description for the changelog**
Added an example for a working catalogsource that can be used for installing the Operator via the web console