### PR TITLE
increase memory limits and requests for manager container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,8 +49,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 40Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION

**- Description of the problem which is fixed/What is the use case**
On OCP 4.7 clusters we have repeatedly seen the operator pod run into
OOM errors. The manager container is usually using around 40M and the limit was
30M.

**- What I did**
 This patch increases the memory limit for the manager container in
the pod to 60M and the request value to 45M.

**- How to verify it**
Install Kata with the operator and uninstall, let it run for half an hour. There should be no restarts
of the operator pod and no OOM errors.

**- Description for the changelog**
Increase memory limit and requests values for the manager container to limit 60M and request 45M

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

