### PR TITLE
forward-port from release-4.6: add support for master/worker combined nodes

### DIFF
--- a/controllers/openshift_controller_test.go
+++ b/controllers/openshift_controller_test.go
@@ -52,6 +52,38 @@ var _ = Describe("OpenShift KataConfig Controller", func() {
 			By("Creating marking the second KataConfig CR correctly")
 			Expect(kataconfig2.Status.InstallationStatus.Failed.FailedNodesCount).Should(Equal(-1))
 		})
-	})
+		It("Should return master in combined master/worker cluster", func() {
+			const (
+				name = "example-kataconfig"
+			)
 
+			kataconfig := &kataconfigurationv1.KataConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kataconfiguration.openshift.io/v1",
+					Kind:       "KataConfig",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			}
+
+			key := types.NamespacedName{
+				Name:      "example-kataconfig",
+				Namespace: "kata-operator-system",
+			}
+
+			const timeout = time.Second * 30
+			const interval = time.Second * 1
+
+			By("Creating the KataConfig CR successfully")
+			Expect(k8sClient.Create(context.Background(), kataconfig)).Should(Succeed())
+			time.Sleep(time.Second * 5)
+
+			exampleKataconfig := &kataconfigurationv1.KataConfig{}
+			Eventually(func() bool {
+				k8sClient.Get(context.Background(), key, exampleKataconfig)
+				return exampleKataconfig.Status.TotalNodesCount == exampleKataconfig.Status.InstallationStatus.Completed.CompletedNodesCount
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -57,8 +58,15 @@ var _ = BeforeSuite(func(done Done) {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 
 	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	t := true
+	if os.Getenv("TEST_USE_EXISTING_CLUSTER") == "true" {
+		testEnv = &envtest.Environment{
+			UseExistingCluster: &t,
+		}
+	} else {
+		testEnv = &envtest.Environment{
+			CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+		}
 	}
 
 	var err error


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

In some compact clusters variants nodes have both the master and worker
role.  However, the machine config pools that are used in these
configurations have all nodes in the master pool and zero nodes in the
worker pool.

**- What I did**

Zero nodes in the worker pool breaks our current practice of installing
kata on all nodes in the worker pool. The solution is to install on all
nodes in the master pool instead. For that we fetch the worker pool
information and check if it has nodes in it. If it has a machine count
of zero we use the master pool instead.

This has an important implication: in this master-only configuration we
can't support installing on a subset of nodes by setting a label on the
selected nodes the user wants to install kata on. Why? This feature
depends on creating a custom pool that inherits from the worker pool.
MCP only supports inheriting from the worker pool but not from the
master pool. See
https://github.com/openshift/machine-config-operator/blob/master/docs/custom-pools.md

This is a trade-off for being able to support these compact cluster
types.

Signed-off-by: Jens Freimann <jfreimann@redhat.com>

**- How to verify it**

On a cluster with 3 (actually the number doesn't matter) combined master/worker nodes run the operator, create/delete a kataconfig CR to install and uninstall. It should complete without errors.

**- Description for the changelog**
Add support for clusters where nodes have both the master and worker role