### PR TITLE
use digests for kube-rbac-proxy and kata-operator-daemon images

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:e10d1d982dd653db74ca87a1d1ad017bc5ef1aeb651bdea089debf16485b080b
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -166,7 +166,7 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCR(operation DaemonOp
 					Containers: []corev1.Container{
 						{
 							Name:            "kata-install-pod",
-							Image:           "quay.io/isolatedcontainers/kata-operator-daemon:4.7",
+							Image:           "quay.io/isolatedcontainers/kata-operator-daemon@sha256:e34f796499ad304b82833904c27aa1fef837df5ec33851a14a722bc2c4eeaea3",
 							ImagePullPolicy: "Always",
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: &runPrivileged,


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**

In disconnected environments container images are mirrored to a local
system. A imageContentSourcePolicy resource needs to be created that
points to the mirrored image. Since OCP 4.3 the default behaviour of
ICSP is mirror-by-digest-only.

**- What I did**
For ease of use in disconnected environment this patch switches the
references to container images in the operator code to use digests
instead of tags.

This patch is not changing the daemon to download the payload image via
digests on purpose. For disconnected environments the configmap for
payloads can be used.

**- How to verify it**

Verify that the images used during installation - manager, kube-rbac-proxy 
and kata-operator-daemon - show up with @sha256:<somehash> in the pods
description

Signed-off-by: Jens Freimann <jfreimann@redhat.com>






**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
