### PR TITLE
controllers: Prevent host devices from being passed to privileged containers

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -345,6 +345,7 @@ func generateDropinConfig(handlerName string) (string, error) {
   runtime_path = "/usr/bin/containerd-shim-kata-v2"
   runtime_type = "vm"
   runtime_root = "/run/vc"
+  privileged_without_host_devices = true
   
 [crio.runtime.runtimes.runc]
   runtime_path = ""


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
**- Description of the problem which is fixed/What is the use case**
`privileged_without_host_devices` is an option from CRI-O configuration
files that controls whether the runtime handler will prevent host
devices from being passed to privileged containers.  Its default value
is `false` and we're switching it to `true` in order to avoid exposing
the host's `/dev`.

**- What I did**
Enforced `privileged_without host_devices = true` for our installation.

**- How to verify it**
When using `privileged: true`, check the content of `/dev` in the container.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Prevent host devices from being passed to privileged containers

**- Notes**
@bpradipt, @dgibson, I'm not exactly sure how it'd break (or not) SR-IOV and would be really nice if you guys could give it a try.  You don't need the operator or anything like that, just changing the CRI-O configuration file in your node (take a look at the changes provided here) and restarting CRI-O should be enough.

@jensfr, @zanetworker, we can't blindly merged this and we may need to find a solution based on different use cases. Anyhow, I'm opening the PR so we have a place to discuss, to figure out the limitations, and to gather ideas about how to proceed with this.