### PR TITLE
set imagePullPolicy to Always for controller container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,6 +46,7 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
I've seen it several times that although a new image was pushed it wasn't
used on my cluster when it had been pulled down in a previous attempt already.

**- What I did**
We want to make sure that the latest controller image is used,
so have the image always pulled down by setting ImagePullPolicy to always.

**- How to verify it**
Test installing/uninstalling twice in a row with updating the image in between. If the description
of the controller pod says "image has already been pulled" it doesn't work.

**- Description for the changelog**
Always pull down latest container image of the controller