### PR TITLE
Daemon authenticate for payload image download

### DIFF
--- a/controllers/openshift_controller.go
+++ b/controllers/openshift_controller.go
@@ -127,6 +127,7 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCR(operation DaemonOp
 		runPrivileged           = true
 		configmapOptional       = true
 		runAsUser         int64 = 0
+		trueValue               = true
 	)
 
 	dsName := "kata-operator-daemon-" + string(operation)
@@ -187,6 +188,30 @@ func (r *KataConfigOpenShiftReconciler) processDaemonsetForCR(operation DaemonOp
 								},
 							},
 							Env: []corev1.EnvVar{
+								{
+									Name: "PAYLOAD_REGISTRY_USERNAME",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "payload-secret",
+											},
+											Key:      "username",
+											Optional: &trueValue,
+										},
+									},
+								},
+								{
+									Name: "PAYLOAD_REGISTRY_PASSWORD",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "payload-secret",
+											},
+											Key:      "password",
+											Optional: &trueValue,
+										},
+									},
+								},
 								{
 									Name: "KATA_PAYLOAD_IMAGE",
 									ValueFrom: &corev1.EnvVarSource{

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -18,6 +18,35 @@ change
 
     daemon.payload: quay.io/<username>/mykatapayload:mytag
 
+## Payload container images in private repositories
+
+When a payload image is stored in a private repository the daemon
+needs to authenticate with the registry to be able to download it.
+
+There are two environment variables defined in the daemons pod specification.
+These variables are populated by a Kubernetes secret that the user can create.
+It has to be created before the daemon pods are created.
+
+Steps to use a payload image in a private repository:
+
+1. deploy the operator as usual
+2. create the payload configmap and set daemon.payload to the path in
+   the private repository, for example
+   quay.io/jensfr/kata-operator-payload:special
+3. create the kubernetes secret with the credentials to above private
+   repository. An example:
+
+   apiVersion: v1
+     kind: Secret
+   metadata:
+     name: payload-secret   <- has to have this exact name
+   data:
+     username: ajVXe2ZyCg=y <- base64 encoded
+     password: emFmekIaOKMN <- base64 encoded
+
+4. create the Kataconfig custom ressource. From here on the
+   installation works as usual.
+
 ## How to create a custom payload container image
 
 Based on an existing and known to work set of RPMs it is possible to replace


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
 When a payload image is stored in a private repository the daemon
    needs to authenticate with the registry to be able to download it.

**- What I did**
Two sets of changes, one in the controller the other one in the daemon.
controller:

>When using a private repository for the payload image the
>daemon can now use the authentification credentials from a
>Kubernetes secret that is provided by the user.
>     
>This patch adds two environment variables for username and password
>to the daemon pod specification. The values are taken from a
>secret that the user needs to create before the pods are created.
>The environment variables are declared as optional so that no error
>occurs without the secret.
>

daemon:

>When a payload image is stored in a private repository the daemon
>needs to authenticate with the registry to be able to download it.
>     
>There are two environment variables defined in the daemons pod
>specification. These variables are populated by a Kubernetes secret that
>the user can create. It needs to be created before the daemons start to
>run.
>The variables and the secret are optional and will only be used when
>a configmap for a custom payload image is used. See the documentation
>for instructions for how to use the configmap and the secret for custom
>payload containers.



**- How to verify it**
See description in docs/DEVELOPMENT.md

**- Description for the changelog**
Allow using payload containers in private repositories by providing credentials with a secret.