### PR TITLE
make sure images are pushed as schema v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ generate: controller-gen
 
 # Build the docker image
 docker-build: test
-	docker build . -t ${IMG}
+	podman build --squash-all --no-cache . -t ${IMG}
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
**- Description of the problem which is fixed/What is the use case**
On the second push to a repository in quay.io all images are converted
to schema v1. 

**- What I did**
To work around this bug we build the container image
with --no-cache --squash-all

**- How to verify it**
Run 'make docker-build IMG=' and push it. Then push it again. Inspect the image
with 'skopeo inspect' and verify it is still in schema v2 format.

**- Description for the changelog**
Make sure container image is stored in schema v2 format.